### PR TITLE
perf: switch run_indexer.py to ProcessPoolExecutor for AST parsing

### DIFF
--- a/n3mo/core/run_indexer.py
+++ b/n3mo/core/run_indexer.py
@@ -446,11 +446,11 @@ def run_indexer_for_path(target_dir):
         indexed_count = 0
 
         if files_to_index:
-            logger.info(f"🧠 Extracting symbols in parallel using ThreadPool ({min(len(files_to_index), os.cpu_count() or 2)} workers)...")
+            logger.info(f"🧠 Extracting symbols in parallel using ProcessPool ({min(len(files_to_index), os.cpu_count() or 2)} workers)...")
             
-            from concurrent.futures import ThreadPoolExecutor
+            from concurrent.futures import ProcessPoolExecutor
             max_workers = min(len(files_to_index), os.cpu_count() or 2)
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            with ProcessPoolExecutor(max_workers=max_workers) as executor:
                 # Submit only the files that need parsing
                 future_to_file = {
                     executor.submit(parse_single_file, fpath): (fpath, rpath, chash)


### PR DESCRIPTION
## Summary
Switches AST symbol extraction in `run_indexer.py` from `ThreadPoolExecutor` to `ProcessPoolExecutor` so parsing bypasses the GIL and achieves true multi-core parallelism on large monorepos. Fixes #31.

## Changes
- Replaced `ThreadPoolExecutor` import with `ProcessPoolExecutor` in `n3mo/core/run_indexer.py`
- Updated executor instantiation from `ThreadPoolExecutor(max_workers=max_workers)` to `ProcessPoolExecutor(max_workers=max_workers)`
- Updated log message from "ThreadPool" to "ProcessPool" to reflect the new execution model
- `parse_single_file` is already a top-level, picklable function, so no refactor was needed for it to work across process boundaries

## Testing
- Ran `pytest tests/` — all tests pass
- Ran `ruff check n3mo/` and `mypy n3mo/` — no new issues
- Manually indexed a multi-file sample repo to confirm output parity with the previous threaded implementation and no deadlocks/hangs